### PR TITLE
Fix `html_logo` rendering.

### DIFF
--- a/sphinx_library/about.html
+++ b/sphinx_library/about.html
@@ -1,17 +1,13 @@
-{%- if logo %}
+{%- if logo_url %}
 <p class="logo">
   <a href="{{ pathto(master_doc)|e }}" title="{{ project }}">
-    {% if '://' in logo %}
-    <img class="logo" src="{{ logo }}" alt="{{ project }}"/>
-    {% else %}
-    <img class="logo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="{{ project }}"/>
-    {% endif %}
+    <img class="logo" src="{{ logo_url }}" alt="{{ project }}"/>
   </a>
 </p>
 {%- endif %}
 
 {% if theme_show_project_name|tobool %}
-<h1 class="logo {% if logo %}hasimg{% endif %}">
+<h1 class="logo {% if logo_url %}hasimg{% endif %}">
   <a href="{{ pathto(master_doc) }}">{{ project }}</a>
 </h1>
 {% endif %}


### PR DESCRIPTION
At least with modern sphinx, there seems to be no `logo` global variable
defined in template context, but there is a `logo_url` global variable:
https://www.sphinx-doc.org/en/master/development/templating.html#logo_url

Fixes #1